### PR TITLE
V2: Mission Control Space name injection via CGSSpaceSetName

### DIFF
--- a/Sources/CGSPrivate/include/CGSPrivate.h
+++ b/Sources/CGSPrivate/include/CGSPrivate.h
@@ -28,4 +28,7 @@ extern CFArrayRef CGSCopyManagedDisplaySpaces(CGSConnectionID cid);
 // Get the currently active space
 extern CGSSpaceID CGSGetActiveSpace(CGSConnectionID cid);
 
+// Set the display name for a Space (appears in Mission Control)
+extern CGError CGSSpaceSetName(CGSConnectionID cid, CGSSpaceID sid, CFStringRef name);
+
 #endif /* CGSPrivate_h */

--- a/Sources/SpaceRenamer/SpaceManager.swift
+++ b/Sources/SpaceRenamer/SpaceManager.swift
@@ -139,6 +139,9 @@ final class SpaceManager {
                 spaces[index].shortcut = config.shortcut
                 cachedSpaces[uuid]?.customName = config.name
                 cachedSpaces[uuid]?.shortcut = config.shortcut
+
+                // Push saved name to Mission Control
+                applyNameToSystem(spaces[index])
             }
         }
     }
@@ -191,6 +194,9 @@ final class SpaceManager {
                 spaces[index].isActive = true
             }
         }
+
+        // Re-apply custom names to Mission Control (survives Dock restarts)
+        applyAllCustomNamesToSystem()
 
         // Notify if active space changed
         if activeId != previousActiveId {
@@ -266,6 +272,9 @@ final class SpaceManager {
                 savedConfigs[spaceId] = AppConfig.SpaceConfig(name: newName)
             }
 
+            // Push name to Mission Control
+            applyNameToSystem(spaces[index])
+
             onSpaceUpdated?(spaces[index])
         }
     }
@@ -287,6 +296,21 @@ final class SpaceManager {
             }
 
             onSpaceUpdated?(spaces[index])
+        }
+    }
+
+    // MARK: - Mission Control Name Injection
+
+    /// Push the custom name to the system so it appears in Mission Control
+    private func applyNameToSystem(_ space: SpaceInfo) {
+        let cfName = space.customName as CFString
+        CGSSpaceSetName(cgsConnection, CGSSpaceID(space.numericId), cfName)
+    }
+
+    /// Re-apply all custom names to the system (survives Dock restarts and topology changes)
+    private func applyAllCustomNamesToSystem() {
+        for space in spaces where !space.customName.hasPrefix("Desktop ") {
+            applyNameToSystem(space)
         }
     }
 

--- a/Sources/SpaceRenamer/SpaceManager.swift
+++ b/Sources/SpaceRenamer/SpaceManager.swift
@@ -110,6 +110,10 @@ final class SpaceManager {
     @ObservationIgnored
     private var savedConfigs: [String: AppConfig.SpaceConfig] = [:]
 
+    /// Tracks known space UUIDs to detect topology changes
+    @ObservationIgnored
+    private var lastKnownSpaceUUIDs: Set<String> = []
+
     init() {
         self.cgsConnection = CGSMainConnectionID()
         setupNotifications()
@@ -195,8 +199,12 @@ final class SpaceManager {
             }
         }
 
-        // Re-apply custom names to Mission Control (survives Dock restarts)
-        applyAllCustomNamesToSystem()
+        // Re-apply custom names only when topology changes (space added/removed)
+        let currentUUIDs = Set(spaceArray.map(\.id))
+        if currentUUIDs != lastKnownSpaceUUIDs {
+            lastKnownSpaceUUIDs = currentUUIDs
+            applyAllCustomNamesToSystem()
+        }
 
         // Notify if active space changed
         if activeId != previousActiveId {
@@ -303,13 +311,17 @@ final class SpaceManager {
 
     /// Push the custom name to the system so it appears in Mission Control
     private func applyNameToSystem(_ space: SpaceInfo) {
+        guard space.numericId != 0 else { return }
         let cfName = space.customName as CFString
-        CGSSpaceSetName(cgsConnection, CGSSpaceID(space.numericId), cfName)
+        let err = CGSSpaceSetName(cgsConnection, CGSSpaceID(space.numericId), cfName)
+        if err != .success {
+            print("[SpaceRenamer] CGSSpaceSetName failed for space \(space.numericId): \(err.rawValue)")
+        }
     }
 
     /// Re-apply all custom names to the system (survives Dock restarts and topology changes)
     private func applyAllCustomNamesToSystem() {
-        for space in spaces where !space.customName.hasPrefix("Desktop ") {
+        for space in spaces where savedConfigs[space.id] != nil {
             applyNameToSystem(space)
         }
     }


### PR DESCRIPTION
#### Description

- Adds `CGSSpaceSetName` declaration to `CGSPrivate.h` bridging header for setting Space display names via SkyLight framework
- Adds `applyNameToSystem(_:)` and `applyAllCustomNamesToSystem()` to SpaceManager that push custom names to the system
- Wires name propagation into three trigger points: user rename, app launch (loadSavedConfigs), and every topology refresh (updateSpaces)
- Custom Space names now appear in Mission Control without requiring SIP to be disabled

#### Test Plan

- Build with `swift build` and launch SpaceRenamer
- Rename a Space via the menu bar UI or quick rename panel
- Open Mission Control (swipe up with three fingers or press F3) — the custom name should appear instead of "Desktop N"
- Restart the app — saved names should re-apply on launch
- Kill Dock (`killall Dock`) — names should re-apply on the next topology refresh (within 3s poll)

#### Screenshots